### PR TITLE
Carefully unset proxy in apt

### DIFF
--- a/zetproxy
+++ b/zetproxy
@@ -58,7 +58,7 @@ proxy_apt()
 	if [ $WIFI_PROXY = "None" ]
 	then
 		echo '  -> Clearing apt proxy everywhere ...'
-        printf "Acquire::http::Proxy \"false\";" > ./.temp_file_apt;
+        printf "" > ./.temp_file_apt;
     else
 		printf "Acquire::http::Proxy \"$hp_pr\";\nAcquire::https::Proxy \"$hsp_pr\";\nAcquire::ftp::Proxy \"$fp_pr\";\n" > ./.temp_file_apt;
 		#echo Created apt.conf file


### PR DESCRIPTION
Fixes #42

Instead of setting `Acquire::http::Proxy` which causes problems to other programs, I have simply deleted this line.